### PR TITLE
Add missing "extra_kwargs" item to config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Example configuration:
       type: "compute"
       provider: "rackspace"
       region: "iad"
+    gce:
+      api_key: "service account email"
+      api_secret: "path to pem file"
+      type: "compute"
+      provider: "gce"
+      # Arbitrary driver constructor arguments can be passed by utilizing extra_kwargs
+      # config option
+      extra_kwargs:
+        project: "your project id"
+        datacenter: "us-central1-a"
 ```
 
 **Note** : When modifying the configuration in `/opt/stackstorm/configs/` please

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -37,6 +37,10 @@ providers:
       description: "Provider region (if required)"
       type: "string"
       required: false
+    extra_kwargs:
+      description: "Additional keyword arguments passed to the drive constructor (e.g. 'project' for GCE, etc.)"
+      type: "object"
+      required: false
     host:
       description: "Provider host if required - e.g. for Kubernetes"
       type: "string"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -38,7 +38,7 @@ providers:
       type: "string"
       required: false
     extra_kwargs:
-      description: "Additional keyword arguments passed to the drive constructor (e.g. 'project' for GCE, etc.)"
+      description: "Additional keyword arguments passed to the driver constructor (e.g. 'project' for GCE, etc.)"
       type: "object"
       required: false
     host:

--- a/libcloud.yaml.example
+++ b/libcloud.yaml.example
@@ -39,3 +39,11 @@
       type: "container"
       provider: "kubernetes"
       host: "12.34.56.67"
+    gce:
+      api_key: "service account email"
+      api_secret: "path to pem file"
+      type: "compute"
+      provider: "gce"
+      extra_kwargs:
+          project: "your project id"
+          datacenter: "us-central1-a"

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,6 +19,6 @@ keywords:
   - cloudsigma
   - gce
   - google compute engine
-version: 0.4.1
+version: 0.4.2
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This pack allowed user to pass arbitrary keyword arguments to the driver constructor by utilizing `extra_kwargs` config option, but when we added config schema support, we missed this config option so users weren't able to utilize the pack with drivers which require non standard driver constructor arguments (e.g. `project` for GCE, etc).

This pull request fixes that.

## TODO

- [ ] Test it (need to dig out my GCE credentials)