### PR TITLE
Update pack so it also works with providers which take single single credentials argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.4.3
+
+- Update pack so it also works with providers such as Vultr which only take a single credential
+  argument - either ``api_key`` or ``api_secret``. Previously it only worked with providers which
+  took both.
+
 # 0.4.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -64,9 +64,14 @@ class BaseAction(Action):
 
         cls = get_driver(provider_config['provider'])
 
-        driver_args = [provider_config['api_key'],
-                       provider_config['api_secret']]
+        driver_args = []
         driver_kwargs = {}
+
+        if provider_config.get('api_key', None):
+            driver_args.append(provider_config['api_key'])
+
+        if provider_config.get('api_secret', None):
+            driver_args.append(provider_config['api_secret'])
 
         if 'region' in provider_config:
             driver_kwargs['region'] = provider_config['region']

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -9,15 +9,36 @@ credentials:
 
 providers:
   type: "object"
+  # Note: We require either api_key or api_secret or both. Some providers such as Vultr only take
+  # a single parameter (key / secret)
+  anyOf:
+    -
+      properties:
+        api_key:
+          required: true
+        api_secret:
+          required: true
+    -
+      properties:
+        api_key:
+          required: true
+        api_secret:
+          required: false
+    -
+      properties:
+        api_key:
+          required: true
+        api_secret:
+          required: false
   properties:
     api_key:
       description: "Credentials for provider"
       type: "string"
-      required: true
+      required: false
     api_secret:
       description: "Secret for provider"
       type: "string"
-      required: true
+      required: false
       secret: true
     type:
       description: "Provider type - e.g. compute, storage, dns"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -27,9 +27,9 @@ providers:
     -
       properties:
         api_key:
-          required: true
-        api_secret:
           required: false
+        api_secret:
+          required: true
   properties:
     api_key:
       description: "Credentials for provider"

--- a/libcloud.yaml.example
+++ b/libcloud.yaml.example
@@ -27,6 +27,10 @@
       api_secret: "password"
       type: "compute"
       provider: "exoscale"
+    vultr_dev:
+      api_secret: "my-api-secret"
+      type: "compute"
+      provider: "vultr"
     aws_ecs:
       api_key: "username"
       api_secret: "blah blah"

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,6 +19,6 @@ keywords:
   - cloudsigma
   - gce
   - google compute engine
-version: 0.4.2
+version: 0.4.3
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request updates pack config schema and code so it also works with providers such as Vultr which take a single credentials argument - either ``api_key`` or ``api_secret``.

Previously it only worked with providers which took both because both of the config items were marked as required.