### PR TITLE
Upgrade to latest version of libcloud, GCE compute action fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,10 @@
 
 # 0.5.0
 
-- Upgrade to apache-libcloud ``v2.6.0``.
+- Upgrade to apache-libcloud ``v2.6.0``. #8
 
 - Fix ``reboot_vm``, ``destroy_vm``, ``start_vm`` and other VM actions so they work correctly with
-  the Google Compute Engine (GCE) driver.
+  the Google Compute Engine (GCE) driver. #8
 
 # 0.4.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 0.5.0
+
+- Upgrade to apache-libcloud ``v2.6.0``.
+
+- Fix ``reboot_vm``, ``destroy_vm``, ``start_vm`` and other VM actions so they work correctly with
+  the Google Compute Engine (GCE) driver.
+
 # 0.4.3
 
 - Update pack so it also works with providers such as Vultr which only take a single credential

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -89,7 +89,9 @@ class SingleVMAction(BaseAction):
         """
         Retrieve Libcloud node instance for the provided node id.
         """
-        if 'GCENodeDriver' in driver.__class__.__name__:
+        from libcloud.compute.drivers.gce import GCENodeDriver
+
+        if isinstance(driver, GCENodeDriver):
             # Special case for GCE driver which relies on "zone" attribute available in node
             # "extra" dictionary
             node = driver.ex_get_node(node_id)

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -89,6 +89,11 @@ class SingleVMAction(BaseAction):
         """
         Retrieve Libcloud node instance for the provided node id.
         """
-        node = Node(id=node_id, name=None, state=None, public_ips=None,
-                    private_ips=None, driver=driver)
+        if 'GCENodeDriver' in driver.__class__.__name__:
+            # Special case for GCE driver which relies on "zone" attribute available in node
+            # "extra" dictionary
+            node = driver.ex_get_node(node_id)
+        else:
+            node = Node(id=node_id, name=None, state=None, public_ips=None,
+                        private_ips=None, driver=driver)
         return node

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - cloudsigma
   - gce
   - google compute engine
-version: 0.4.3
+version: 0.5.0
 python_versions:
   - "2"
   - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-apache-libcloud==2.0.0
+apache-libcloud==2.6.0


### PR DESCRIPTION
This pull request fixes actions which operate on the VM (``stop_vm``, ``start_vm``, ``destroy_vm``, etc.) so they work correctly with Google Compute Engine (GCE) VMs.

GCE driver relies on the ``zone`` attribute being available in the ``node.extra`` dictionary which means we need to retrieve the whole Node objects before we operate it.

As part of this PR, I also upgraded Libcloud to latest stable version.

Thanks to Benoit Lourdelet for reporting this issue.