### PR TITLE
Add "extra_kwargs" parameter to all the actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 - Add new ``extra_kwargs`` parameter to all the available actions. With this parameter, user
   can specify a list of arbitrary keyword arguments which will be passed to the underlying
-  Libcloud driver method.
+  Libcloud driver method. #9
 
 ## v0.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.0
+
+- Add new ``extra_kwargs`` parameter to all the available actions. With this parameter, user
+  can specify a list of arbitrary keyword arguments which will be passed to the underlying
+  Libcloud driver method.
+
 ## v0.5.0
 
 - Upgrade to apache-libcloud ``v2.6.0``. #8

--- a/README.md
+++ b/README.md
@@ -50,22 +50,45 @@ The following actions are supported:
 
 ### Virtual Machines / Servers
 
-* Create a new VM - `create_vm`
-* Reboot a VM - `reboot_vm`
-* Stop a VM - `stop_vm`
-* Start a VM - `start_vm`
-* Destroy a VM - `destroy_vm`
+* List available VMs - ``list_vms``
+* List available VM sizes - ``list_sizes``
+* List available VM images - ``list_images``
+* Create a new VM - ``create_vm``
+* Reboot a VM - ``reboot_vm``
+* Stop a VM - ``stop_vm``
+* Start a VM - ``start_vm``
+* Destroy a VM - ``destroy_vm``
+* Import public SSH key - ``import_public_ssh_key``
 
 ### Storage
 
-* Upload a file to a container - `upload_file`
+* Upload a file to a container - ``upload_file``
 * Enable CDN for a container and retrieve container CDN URL -
-  `enable_cdn_for_container`
-* Retrieve CDN URL of a CDN enabled container - `get_container_cdn_url`
+  ``enable_cdn_for_container``
+* Retrieve CDN URL of a CDN enabled container - ``get_container_cdn_url``
 * Retrieve CDN URL for an object which is stored in a CDN enabled container -
-  `get_object_cdn_url`
+  ``get_object_cdn_url``
 
 ### DNS
 
-* Create a new DNS record - `create_dns_record`
-* Delete an existing DNS record - `delete_dns_record`
+* Create a new DNS record - ``create_dns_record``
+* Delete an existing DNS record - ``delete_dns_record``
+* List DNS records for a particual zone ``list_dns_records``
+* List available DNS zones - ``list_dns_zones``
+
+### LoadBalancer
+
+* Attach member to the loadbalancer - ``balancer_attach_member``
+* List load balancer members - ``balancer_list_members``
+* Create a new load balancer - ``create_balancer``
+* List load balancers - ``list_balancers``
+
+## Container as a Service
+
+* Create new container cluster - ``create_container_cluster``
+* Deploy a new container to a cluster - ``deploy_container``
+* List available container clusters - ``list_container_clusters``
+* List available containers in a cluster - ``list_container_clusters``
+* Start a container - ``start_container``
+* Stop a container - ``stop_container``
+* Restart a container - ``restart_container``

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following actions are supported:
 * Stop a container - ``stop_container``
 * Restart a container - ``restart_container``
 
-## Passing Libcloud driver specific parameters to the action
+## Passing driver specific arguments to the action
 
 Version ``v0.6.0`` of this pack added support for new ``extra_kwargs`` parameter to all the pack
 actions.

--- a/README.md
+++ b/README.md
@@ -92,3 +92,20 @@ The following actions are supported:
 * Start a container - ``start_container``
 * Stop a container - ``stop_container``
 * Restart a container - ``restart_container``
+
+## Passing Libcloud driver specific parameters to the action
+
+Version ``v0.6.0`` of this pack added support for new ``extra_kwargs`` parameter to all the pack
+actions.
+
+With this parameter, user can specify arbitrary dictionary of additional keyword arguments which
+are passed to the underlying Libcloud driver method.
+
+For example:
+
+```bash
+st2 run libcloud.destroy_vm credentials=gce_dev vm_id=12346, extra_kwargs='{"sync": false}'
+```
+
+Keep in mind that most of those custom arguments are driver specific so you should avoid them
+and only utilize standard parameters if you care about portability across multiple providers.

--- a/actions/balancer_attach_member.py
+++ b/actions/balancer_attach_member.py
@@ -10,10 +10,11 @@ __all__ = [
 class BalancerAttachMemberAction(BaseAction):
     api_type = 'loadbalancer'
 
-    def run(self, credentials, balancer_id, member_ip, member_port):
+    def run(self, credentials, balancer_id, member_ip, member_port, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         balancer = driver.get_balancer(balancer_id)
         member = Member(id=None, ip=member_ip, port=member_port)
         record = driver.balancer_attach_member(balancer=balancer,
-                                               member=member)
+                                               member=member, **extra_kwargs)
         return self.resultsets.formatter(record)

--- a/actions/balancer_attach_member.yaml
+++ b/actions/balancer_attach_member.yaml
@@ -21,3 +21,7 @@ parameters:
     type: string
     description: The TCP/UDP port of the member
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/balancer_list_members.py
+++ b/actions/balancer_list_members.py
@@ -8,8 +8,9 @@ __all__ = [
 class BalancerListMembersAction(BaseAction):
     api_type = 'loadbalancer'
 
-    def run(self, credentials, balancer_id):
+    def run(self, credentials, balancer_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         balancer = driver.get_balancer(balancer_id)
-        members = driver.balancer_list_members(balancer=balancer)
+        members = driver.balancer_list_members(balancer=balancer, **extra_kwargs)
         return self.resultsets.formatter(members)

--- a/actions/balancer_list_members.yaml
+++ b/actions/balancer_list_members.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of the load balancer
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/create_balancer.py
+++ b/actions/create_balancer.py
@@ -11,7 +11,8 @@ class CreateBalancerAction(BaseAction):
     api_type = 'loadbalancer'
 
     def run(self, credentials, name, port, protocol,
-            algorithm=Algorithm.ROUND_ROBIN):
+            algorithm=Algorithm.ROUND_ROBIN, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
         # Use a local lookup - these maps are protected fields of each driver
@@ -29,5 +30,6 @@ class CreateBalancerAction(BaseAction):
                                         port=port,
                                         protocol=protocol,
                                         algorithm=algorithm,
-                                        members=None)
+                                        members=None,
+                                        **extra_kwargs)
         return self.resultsets.formatter(record)

--- a/actions/create_balancer.yaml
+++ b/actions/create_balancer.yaml
@@ -26,3 +26,7 @@ parameters:
     description: The algorithm of the balancer, choice of LEAST_CONNECTIONS, ROUND_ROBIN, SHORTEST_RESPONSE, PERSISTENT_IP
     required: false
     default: "ROUND_ROBIN"
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/create_container_cluster.py
+++ b/actions/create_container_cluster.py
@@ -8,8 +8,9 @@ __all__ = [
 class CreateContainerClusterAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, name):
+    def run(self, credentials, name, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
-        record = driver.create_cluster(name=name)
+        record = driver.create_cluster(name=name, **extra_kwargs)
         return self.resultsets.formatter(record)

--- a/actions/create_container_cluster.yaml
+++ b/actions/create_container_cluster.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: The name of the cluster
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/create_dns_record.py
+++ b/actions/create_dns_record.py
@@ -8,7 +8,9 @@ __all__ = [
 class CreateDNSRecordAction(BaseAction):
     api_type = 'dns'
 
-    def run(self, credentials, domain, name, type, data, ttl=500):
+    def run(self, credentials, domain, name, type, data, ttl=500,
+            extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         zones = driver.list_zones()
 
@@ -20,7 +22,8 @@ class CreateDNSRecordAction(BaseAction):
         extra = {'ttl': int(ttl)}
         record = driver.create_record(name=name, zone=zone,
                                       type=type,
-                                      data=data, extra=extra)
+                                      data=data, extra=extra,
+                                      **extra_kwargs)
 
         self.logger.info('Successfully created record "%s"' % (record.name))
         return record

--- a/actions/create_dns_record.yaml
+++ b/actions/create_dns_record.yaml
@@ -35,3 +35,7 @@ parameters:
     description: Record TTL
     position: 5
     default: 500
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/create_vm.py
+++ b/actions/create_vm.py
@@ -12,7 +12,8 @@ class CreateVMAction(BaseAction):
     api_type = 'compute'
 
     def run(self, credentials, name, size_id=None, image_id=None, size_name=None, image_name=None,
-            location_id=None):
+            location_id=None, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         location = NodeLocation(id=location_id, name=None,
                                 country=None, driver=driver)
@@ -40,6 +41,8 @@ class CreateVMAction(BaseAction):
 
         if location_id:
             kwargs['location'] = location
+
+        kwargs.update(extra_kwargs)
 
         self.logger.info('Creating node...')
 

--- a/actions/create_vm.yaml
+++ b/actions/create_vm.yaml
@@ -28,3 +28,7 @@ parameters:
   location_id:
     type: string
     description: ID of a location to use
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/delete_dns_record.py
+++ b/actions/delete_dns_record.py
@@ -11,13 +11,14 @@ __all__ = [
 class DeleteDNSRecordAction(BaseAction):
     api_type = 'dns'
 
-    def run(self, credentials, zone_id, record_id):
+    def run(self, credentials, zone_id, record_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         zone = Zone(id=zone_id, domain=None, type=None, ttl=None, driver=driver)
         record = Record(id=record_id, name=None, type=None, data=None,
                         zone=zone, driver=driver)
 
-        status = driver.delete_record(record=record)
+        status = driver.delete_record(record=record, **extra_kwargs)
 
         if status:
             self.logger.info('Successfully deleted record')

--- a/actions/deploy_container.py
+++ b/actions/deploy_container.py
@@ -11,7 +11,8 @@ class DeployContainerAction(BaseAction):
     api_type = 'container'
 
     def run(self, credentials, name, repository_name, tag,
-            start, cluster_id=None, parameters=None):
+            start, cluster_id=None, parameters=None, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         hub_client = HubClient()
         image = hub_client.get_image(repository_name, tag)
@@ -21,5 +22,5 @@ class DeployContainerAction(BaseAction):
             cluster = None
         record = driver.deploy_container(name=name, image=image,
                                          start=start, cluster=cluster,
-                                         parameters=parameters)
+                                         parameters=parameters, **extra_kwargs)
         return self.resultsets.formatter(record)

--- a/actions/deploy_container.yaml
+++ b/actions/deploy_container.yaml
@@ -33,3 +33,7 @@ parameters:
     type: string
     required: false
     description: The boot parameters for the image
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/destroy_container.py
+++ b/actions/destroy_container.py
@@ -8,12 +8,13 @@ __all__ = [
 class DestroyContainerAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, container_id):
+    def run(self, credentials, container_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         container = driver.get_container(container_id)
 
         self.logger.info('Destroying container: %s...' % (container))
-        status = driver.destroy_container(container)
+        status = driver.destroy_container(container, **extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully destroyed container "%s"' % (container))

--- a/actions/destroy_container.yaml
+++ b/actions/destroy_container.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a container to destroy.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/destroy_vm.py
+++ b/actions/destroy_vm.py
@@ -8,12 +8,13 @@ __all__ = [
 class DestroyVMAction(SingleVMAction):
     api_type = 'compute'
 
-    def run(self, credentials, vm_id):
+    def run(self, credentials, vm_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         node = self._get_node_for_id(node_id=vm_id, driver=driver)
 
         self.logger.info('Destroying node: %s...' % (node))
-        status = driver.destroy_node(node=node)
+        status = driver.destroy_node(node=node, **extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully destroyed node "%s"' % (node))

--- a/actions/destroy_vm.yaml
+++ b/actions/destroy_vm.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a VM to destroy.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/enable_cdn_for_container.py
+++ b/actions/enable_cdn_for_container.py
@@ -8,11 +8,12 @@ __all__ = [
 class EnableContainerCDN(BaseAction):
     api_type = 'storage'
 
-    def run(self, credentials, container_name):
+    def run(self, credentials, container_name, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
         container = driver.get_container(container_name=container_name)
-        driver.enable_container_cdn(container=container)
+        driver.enable_container_cdn(container=container, **extra_kwargs)
         container_cdn_url = driver.get_container_cdn_url(container=container)
 
         result = {'url': container_cdn_url}

--- a/actions/enable_cdn_for_container.yaml
+++ b/actions/enable_cdn_for_container.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: Name of the container to enable the CDN for.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/get_container_cdn_url.py
+++ b/actions/get_container_cdn_url.py
@@ -8,11 +8,12 @@ __all__ = [
 class GetContainerCDNURL(BaseAction):
     api_type = 'storage'
 
-    def run(self, credentials, container_name):
+    def run(self, credentials, container_name, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
         container = driver.get_container(container_name=container_name)
-        container_cdn_url = driver.get_container_cdn_url(container=container)
+        container_cdn_url = driver.get_container_cdn_url(container=container, **extra_kwargs)
 
         result = {'url': container_cdn_url}
         return result

--- a/actions/get_container_cdn_url.yaml
+++ b/actions/get_container_cdn_url.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: Name of the container to retrieve the CDN URL for.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/get_object_cdn_url.py
+++ b/actions/get_object_cdn_url.py
@@ -8,12 +8,13 @@ __all__ = [
 class GetObjectCDNURL(BaseAction):
     api_type = 'storage'
 
-    def run(self, credentials, container_name, object_name):
+    def run(self, credentials, container_name, object_name, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
         obj = driver.get_object(container_name=container_name,
                                 object_name=object_name)
-        object_cdn_url = driver.get_object_cdn_url(obj=obj)
+        object_cdn_url = driver.get_object_cdn_url(obj=obj, **extra_kwargs)
 
         result = {'url': object_cdn_url}
         return result

--- a/actions/get_object_cdn_url.yaml
+++ b/actions/get_object_cdn_url.yaml
@@ -17,3 +17,7 @@ parameters:
     type: string
     description: Name of the object.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/import_public_ssh_key.py
+++ b/actions/import_public_ssh_key.py
@@ -8,7 +8,9 @@ __all__ = [
 class ImportPublicSSHKeyAction(BaseAction):
     api_type = 'compute'
 
-    def run(self, credentials, name, key_material):
+    def run(self, credentials, name, key_material, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         return driver.import_key_pair_from_string(name=name,
-                                                  key_material=key_material)
+                                                  key_material=key_material,
+                                                  **extra_kwargs)

--- a/actions/import_public_ssh_key.yaml
+++ b/actions/import_public_ssh_key.yaml
@@ -17,3 +17,7 @@ parameters:
     type: string
     description: Public SSH key material
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_balancers.py
+++ b/actions/list_balancers.py
@@ -8,7 +8,8 @@ __all__ = [
 class ListBalancersAction(BaseAction):
     api_type = 'loadbalancer'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
-        members = driver.list_balancers()
+        members = driver.list_balancers(**extra_kwargs)
         return self.resultsets.formatter(members)

--- a/actions/list_balancers.yaml
+++ b/actions/list_balancers.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_container_clusters.py
+++ b/actions/list_container_clusters.py
@@ -8,7 +8,8 @@ __all__ = [
 class ListContainerClustersAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
-        members = driver.list_clusters()
+        members = driver.list_clusters(**extra_kwargs)
         return self.resultsets.formatter(members)

--- a/actions/list_container_clusters.yaml
+++ b/actions/list_container_clusters.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_containers.py
+++ b/actions/list_containers.py
@@ -8,11 +8,12 @@ __all__ = [
 class ListContainersAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, cluster_id=None):
+    def run(self, credentials, cluster_id=None, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         if cluster_id is not None:
             cluster = driver.get_cluster(cluster_id)
         else:
             cluster = None
-        containers = driver.list_containers(cluster=cluster)
+        containers = driver.list_containers(cluster=cluster, **extra_kwargs)
         return self.resultsets.formatter(containers)

--- a/actions/list_containers.yaml
+++ b/actions/list_containers.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: The ID of the cluster to look in
     required: false
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_dns_records.py
+++ b/actions/list_dns_records.py
@@ -10,8 +10,9 @@ __all__ = [
 class ListDNSRecordsAction(BaseAction):
     api_type = 'dns'
 
-    def run(self, credentials, zone_id):
+    def run(self, credentials, zone_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         zone = Zone(id=zone_id, domain=None, type=None, ttl=None, driver=None)
-        records = driver.list_records(zone=zone)
+        records = driver.list_records(zone=zone, **extra_kwargs)
         return self.resultsets.formatter(records)

--- a/actions/list_dns_records.yaml
+++ b/actions/list_dns_records.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of the zone to list the records for.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_dns_zones.py
+++ b/actions/list_dns_zones.py
@@ -8,7 +8,8 @@ __all__ = [
 class ListDNSZonesAction(BaseAction):
     api_type = 'dns'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
-        zones = driver.list_zones()
+        zones = driver.list_zones(**extra_kwargs)
         return self.resultsets.formatter(zones)

--- a/actions/list_dns_zones.yaml
+++ b/actions/list_dns_zones.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_images.py
+++ b/actions/list_images.py
@@ -8,7 +8,8 @@ __all__ = [
 class ListImagesAction(BaseAction):
     api_type = 'compute'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
-        images = driver.list_images()
+        images = driver.list_images(**extra_kwargs)
         return self.resultsets.formatter(images)

--- a/actions/list_images.yaml
+++ b/actions/list_images.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_sizes.py
+++ b/actions/list_sizes.py
@@ -8,7 +8,8 @@ __all__ = [
 class ListSizesAction(BaseAction):
     api_type = 'compute'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         sizes = driver.list_sizes()
         return self.resultsets.formatter(sizes)

--- a/actions/list_sizes.yaml
+++ b/actions/list_sizes.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/list_vms.py
+++ b/actions/list_vms.py
@@ -8,8 +8,9 @@ __all__ = [
 class ListVMsAction(BaseAction):
     api_type = 'compute'
 
-    def run(self, credentials):
+    def run(self, credentials, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
-        vms = driver.list_nodes()
+        vms = driver.list_nodes(**extra_kwargs)
 
         return self.resultsets.formatter(vms)

--- a/actions/list_vms.yaml
+++ b/actions/list_vms.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: Name of the credentials set (as defined in the config) to use.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/reboot_vm.py
+++ b/actions/reboot_vm.py
@@ -8,12 +8,13 @@ __all__ = [
 class RebootVMAction(SingleVMAction):
     api_type = 'compute'
 
-    def run(self, credentials, vm_id):
+    def run(self, credentials, vm_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         node = self._get_node_for_id(node_id=vm_id, driver=driver)
 
         self.logger.info('Rebooting node: %s' % (node))
-        status = driver.reboot_node(node=node)
+        status = driver.reboot_node(node=node, **extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully rebooted node "%s"' % (node))

--- a/actions/reboot_vm.yaml
+++ b/actions/reboot_vm.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a VM to reboot.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/restart_container.py
+++ b/actions/restart_container.py
@@ -8,12 +8,13 @@ __all__ = [
 class RestartContainerAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, container_id):
+    def run(self, credentials, container_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         container = driver.get_container(container_id)
 
         self.logger.info('Restarting container: %s' % (container))
-        status = container.restart()
+        status = container.restart(**extra_kwargs)
 
         if status is True:
             self.logger.info(

--- a/actions/restart_container.yaml
+++ b/actions/restart_container.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a container to restart.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/start_container.py
+++ b/actions/start_container.py
@@ -8,12 +8,13 @@ __all__ = [
 class StartContainerAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, container_id):
+    def run(self, credentials, container_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         container = driver.get_container(container_id)
 
         self.logger.info('Starting container: %s' % (container))
-        status = container.start()
+        status = container.start(**extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully started container "%s"' % (container))

--- a/actions/start_container.yaml
+++ b/actions/start_container.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a container to start.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/start_vm.py
+++ b/actions/start_vm.py
@@ -8,12 +8,13 @@ __all__ = [
 class StartVMAction(SingleVMAction):
     api_type = 'compute'
 
-    def run(self, credentials, vm_id):
+    def run(self, credentials, vm_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         node = self._get_node_for_id(node_id=vm_id, driver=driver)
 
         self.logger.info('Starting node: %s' % (node))
-        status = driver.ex_start_node(node=node)
+        status = driver.ex_start_node(node=node, **extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully started node "%s"' % (node))

--- a/actions/start_vm.yaml
+++ b/actions/start_vm.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a VM to start.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/stop_container.py
+++ b/actions/stop_container.py
@@ -8,12 +8,13 @@ __all__ = [
 class StopContainerAction(BaseAction):
     api_type = 'container'
 
-    def run(self, credentials, container_id):
+    def run(self, credentials, container_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         container = driver.get_container(container_id)
 
         self.logger.info('Starting container: %s' % (container))
-        status = container.stop()
+        status = container.stop(**extra_kwargs)
 
         if status is True:
             self.logger.info(

--- a/actions/stop_container.yaml
+++ b/actions/stop_container.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a container to stop.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/stop_vm.py
+++ b/actions/stop_vm.py
@@ -8,12 +8,13 @@ __all__ = [
 class StopVMAction(SingleVMAction):
     api_type = 'compute'
 
-    def run(self, credentials, vm_id):
+    def run(self, credentials, vm_id, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
         node = self._get_node_for_id(node_id=vm_id, driver=driver)
 
         self.logger.info('Stopping node: %s' % (node))
-        status = driver.ex_stop_node(node=node)
+        status = driver.ex_stop_node(node=node, **extra_kwargs)
 
         if status is True:
             self.logger.info('Successfully stopped node "%s"' % (node))

--- a/actions/stop_vm.yaml
+++ b/actions/stop_vm.yaml
@@ -13,3 +13,7 @@ parameters:
     type: string
     description: ID of a VM to stop.
     required: true
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/actions/upload_file.py
+++ b/actions/upload_file.py
@@ -12,7 +12,8 @@ __all__ = [
 class UploadFileAction(BaseAction):
     api_type = 'storage'
 
-    def run(self, credentials, file_path, container_name, object_name=None):
+    def run(self, credentials, file_path, container_name, object_name=None, extra_kwargs=None):
+        extra_kwargs = extra_kwargs or {}
         driver = self._get_driver_for_credentials(credentials=credentials)
 
         try:
@@ -24,7 +25,7 @@ class UploadFileAction(BaseAction):
 
         object_name = object_name if object_name else os.path.basename(file_path)
         obj = driver.upload_object(file_path=file_path, container=container,
-                                   object_name=object_name)
+                                   object_name=object_name, **extra_kwargs)
 
         self.logger.info('Object successfully uploaded: %s' % (obj))
         return obj

--- a/actions/upload_file.yaml
+++ b/actions/upload_file.yaml
@@ -22,3 +22,7 @@ parameters:
     description: Name for the uploaded object. If not provided, local file name is
       used.
     required: false
+  extra_kwargs:
+    type: object
+    description: Additional keyword arguments which will be passed to the underlying Libcloud method.
+    required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -19,7 +19,7 @@ keywords:
   - cloudsigma
   - gce
   - google compute engine
-version: 0.5.0
+version: 0.6.0
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
This pull request adds new ``extra_kwargs`` parameter to all the pack actions.

With this parameter, user can specify a dictionary of arbitrary keyword arguments which are passed to the underlying driver method.

Keep in mind that those custom arguments are usually driver specific (not available on all the drivers) so if portability across driver is a concern, this parameter shouldn't be used and only standard / common parameters should be used.